### PR TITLE
[Feat] Geocoding 및 데이터 처리 

### DIFF
--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -8,6 +8,7 @@
       "name": "markpark-back",
       "version": "1.0.0",
       "dependencies": {
+        "axios": "^1.6.8",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
@@ -79,6 +80,21 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -193,6 +209,17 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -265,6 +292,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/denque": {
@@ -421,6 +456,38 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -967,6 +1034,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/back/package.json
+++ b/back/package.json
@@ -7,6 +7,7 @@
     "dev": "nodemon app"
   },
   "dependencies": {
+    "axios": "^1.6.8",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",

--- a/back/utils/dataProcessor.js
+++ b/back/utils/dataProcessor.js
@@ -1,20 +1,58 @@
+require("dotenv").config({ path: "../.env" });
 const fs = require("fs");
+const axios = require("axios");
 let rawData = fs.readFileSync("../data/rawData.json");
 let jsonData = JSON.parse(rawData);
 
-let processedData = jsonData.records.map((record) => {
-  return {
-    parkingName: record.주차장명,
-    parkingType: record.주차장구분,
-    roadAddress: record.소재지도로명주소,
-    address: record.소재지지번주소,
-    feeInfo: record.요금정보,
-    latitude: record.위도,
-    longitude: record.경도,
-  };
-});
+const config = {
+  method: "get",
+  url: "https://naveropenapi.apigw.ntruss.com/map-geocode/v2/geocode",
+  headers: {
+    "X-NCP-APIGW-API-KEY-ID": process.env.NAVER_API_CLIENT_ID,
+    "X-NCP-APIGW-API-KEY": process.env.NAVER_API_CLIENT_SECRET,
+  },
+  params: {
+    query: "",
+  },
+};
 
-fs.writeFileSync(
-  "../data/processedData.json",
-  JSON.stringify(processedData, null, 2)
-);
+async function geocodeAddress(address) {
+  config.params.query = address;
+  try {
+    const response = await axios(config);
+    const lat = response.data.addresses[0].y;
+    const lng = response.data.addresses[0].x;
+    return { latitude: lat, longitude: lng };
+  } catch (error) {
+    return { latitude: "", longitude: "" };
+  }
+}
+
+async function processData(records) {
+  const processedData = [];
+  for (const record of records) {
+    let coords = { latitude: record.위도, longitude: record.경도 };
+    if (
+      !coords.latitude &&
+      (record.소재지지번주소 || record.소재지도로명주소)
+    ) {
+      coords = await geocodeAddress(
+        record.소재지지번주소 || record.소재지도로명주소
+      );
+    }
+    processedData.push({
+      parkingName: record.주차장명,
+      parkingType: record.주차장구분,
+      roadAddress: record.소재지도로명주소,
+      address: record.소재지지번주소,
+      feeInfo: record.요금정보,
+      ...coords,
+    });
+  }
+  fs.writeFileSync(
+    "../data/processedData.json",
+    JSON.stringify(processedData, null, 2)
+  );
+}
+
+processData(jsonData.records);


### PR DESCRIPTION
#3 

- [x] 주소 기반으로 위도와 경도 좌표를 추가하는 기능
- [x] 네이버 지오코딩 API를 활용하여 좌표가 없는 레코드에 지리적 좌표를 제공

- 주소를 기반으로 좌표를 조회하는 geocodeAddress 함수 추가
- 데이터셋의 각 레코드를 처리하는 processData 함수에 조회된 위도, 경도 추가
- 좌표가 없고 주소가 있는 경우에만 새로운 좌표 조회
- API 요청에 axios 사용
- API 인증 정보 보안 관리를 위해 dotenv 사용
- 모든 주차 레코드 JSON 데이터 저장